### PR TITLE
Fix build for Debian 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,15 @@ COPY start-mysql stop-mysql /bin/
 # force MySQL client connection and both client and server default charsets to be UTF-8
 RUN printf "[client]\ndefault-character-set=utf8\n[mysql]\ndefault-character-set=utf8\n[mysqld]\ncharacter-set-server=utf8" >> /etc/mysql/conf.d/charset.cnf
 
+
 # Wrap your MySQL commands with start-mysql and stop-mysql
 # Anything inside will have access to MySQL server
-RUN start-mysql && \
+#
+# The workaround to make build work on Debian 9 is to 'touch' the files used by MySQL.
+# Explanation here:
+# https://docs.docker.com/storage/storagedriver/overlayfs-driver/
+RUN find /var/lib/mysql -type f -exec touch {} \; && \
+    start-mysql && \
     echo "status" | mysql && \
     echo "CREATE USER 'root'@'%'; GRANT ALL ON *.* TO 'root'@'%';" | mysql && \
     stop-mysql

--- a/start-mysql
+++ b/start-mysql
@@ -4,4 +4,3 @@ echo -ne "Starting mysql ... ";
 mysqld --user=mysql --skip-networking --skip-name-resolve --pid-file=/var/run/mysqld/mysqld.pid > /dev/null 2>&1 &
 mysqladmin --silent --wait=30 ping > /dev/null
 echo "Done";
-


### PR DESCRIPTION
@AlexanderZigar-awin, @awin/teamblue, please review.

Build on Debian 9 is failing with the message:
ERROR 2002 (HY000):
Can't connect to local MySQL server through socket
'/var/run/mysqld/mysqld.sock' (2)

The reason for this message is that Debian 9
does not support aufs FS driver anymore and is using overlay2.

MySQL has issues with overlay2,
because it implements only some of POSIX standards.

The workaround is to 'touch' the files used by MySQL.

Explanation here:
https://github.com/docker/for-linux/issues/72#issuecomment-319904698
and here:
https://docs.docker.com/storage/storagedriver/overlayfs-driver/