### PR TITLE
Finalize the build for Debian 9 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,7 @@ RUN printf "[client]\ndefault-character-set=utf8\n[mysql]\ndefault-character-set
 
 # Wrap your MySQL commands with start-mysql and stop-mysql
 # Anything inside will have access to MySQL server
-#
-# The workaround to make build work on Debian 9 is to 'touch' the files used by MySQL.
-# Explanation here:
-# https://docs.docker.com/storage/storagedriver/overlayfs-driver/
-RUN find /var/lib/mysql -type f -exec touch {} \; && \
-    start-mysql && \
+RUN start-mysql && \
     echo "status" | mysql && \
     echo "CREATE USER 'root'@'%'; GRANT ALL ON *.* TO 'root'@'%';" | mysql && \
     stop-mysql

--- a/services.d/mysqld/run
+++ b/services.d/mysqld/run
@@ -1,3 +1,7 @@
 #!/bin/sh
 
+# The workaround to make build work on Debian 9 is to 'touch' the files used by MySQL.
+# Explanation here:
+# https://docs.docker.com/storage/storagedriver/overlayfs-driver/
+find /var/lib/mysql -type f -exec touch {} \; && \
 mysqld --user=mysql --skip-name-resolve --bind-address=0.0.0.0 --pid-file=/var/run/mysqld/mysqld.pid --open-files-limit=5120

--- a/start-mysql
+++ b/start-mysql
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 echo -ne "Starting mysql ... ";
+
+# The workaround to make build work on Debian 9 is to 'touch' the files used by MySQL.
+# Explanation here:
+# https://docs.docker.com/storage/storagedriver/overlayfs-driver/
+find /var/lib/mysql -type f -exec touch {} \;
+
 mysqld --user=mysql --skip-networking --skip-name-resolve --pid-file=/var/run/mysqld/mysqld.pid > /dev/null 2>&1 &
 mysqladmin --silent --wait=30 ping > /dev/null
 echo "Done";


### PR DESCRIPTION
@awin/teamblue, please review.

This is a follow up for the previous commit.
To make the build work, last command in Dockerfile
CMD ["/init"]
also requires "touching" MySQL files.

Including the "touching" hack in start-mysql script
allows downstream projects to avoid changes.